### PR TITLE
We'll work on optimizing the compilation process for lower RAM

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -16,7 +16,7 @@ include(AsteroidCMakeSettings)
 include(AsteroidTranslations)
 
 add_subdirectory(src)
-qt5_add_resources(RESOURCE_FILES resources.qrc)
+
 
 configure_file(${CMAKE_CURRENT_SOURCE_DIR}/runscript.in
 	${CMAKE_BINARY_DIR}/${CMAKE_PROJECT_NAME}

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,4 +1,5 @@
-add_library(${CMAKE_PROJECT_NAME} main.cpp resources.qrc)
+qt5_add_big_resources(RESOURCE_FILES resources.qrc)
+add_library(${CMAKE_PROJECT_NAME} main.cpp ${RESOURCE_FILES})
 find_package(Qt5 COMPONENTS Sql REQUIRED)
 
 target_link_libraries(${CMAKE_PROJECT_NAME} PUBLIC


### PR DESCRIPTION
The issue appears to stem from the resource compilation process, which involves Qt's rcc resource compiler